### PR TITLE
Replace references to deprecated `purescript-spago`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The event types in React Native are a little more rich than they are in React, s
 
 ## Setup
 
-* `npm install purescript-spago expo-cli --global`
+* `npm install spago expo-cli --global`
 * `spago install`
 * `spago build`
 

--- a/examples/controlled-input/README.md
+++ b/examples/controlled-input/README.md
@@ -7,7 +7,7 @@ You type stuff into a text input and it shows you what you typed
 These examples were built with [expo](https://expo.io/) and [spago](https://github.com/spacchetti/spago). 
 
  
-* `npm install purescript-spago expo-cli --global`
+* `npm install spago expo-cli --global`
 * `spago install`
 * `spago build`
 * `npm install`

--- a/examples/controlled-input/README.md
+++ b/examples/controlled-input/README.md
@@ -4,7 +4,7 @@ You type stuff into a text input and it shows you what you typed
 
 ## Instructions
 
-These examples were built with [expo](https://expo.io/) and [spago](https://github.com/spacchetti/spago). 
+These examples were built with [expo](https://expo.io/) and [spago](https://github.com/purescript/spago). 
 
  
 * `npm install spago expo-cli --global`

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -4,7 +4,7 @@ Shows how to make a button that modifies internal state - it increments a counte
 
 ## Instructions
 
-These examples were built with [expo](https://expo.io/) and [spago](https://github.com/spacchetti/spago). 
+These examples were built with [expo](https://expo.io/) and [spago](https://github.com/purescript/spago). 
 
  
 * `npm install spago expo-cli --global`

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -7,7 +7,7 @@ Shows how to make a button that modifies internal state - it increments a counte
 These examples were built with [expo](https://expo.io/) and [spago](https://github.com/spacchetti/spago). 
 
  
-* `npm install purescript-spago expo-cli --global`
+* `npm install spago expo-cli --global`
 * `spago install`
 * `spago build`
 * `npm install`


### PR DESCRIPTION
The `purescript-spago` package has been [deprecated in favor of `spago`](https://www.npmjs.com/package/purescript-spago)
> Please switch to the new package: https://www.npmjs.com/package/spago

This PR edits the install instructions and updates URLs to point to this new package.